### PR TITLE
fix vanishing footnotes at a 2->1column transition

### DIFF
--- a/src/paratext2.tex
+++ b/src/paratext2.tex
@@ -192,7 +192,7 @@
 }
 \def\onecoltrial{% single-column version of \twocoltrial (see below)
   %\tracingall=1\tracingoutput=0\tracingpages=0\tracingparagraphs=0\tracingassigns=0\tracingscantokens=0
-%%%  \msg{TRIAL with ht=\the\trialheight, vsize=\the\vsize}
+%%%  \msg{1c TRIAL with ht=\the\trialheight, vsize=\the\vsize, hIns=\the\holdinginserts}
   \edef\p@gebotmark{\botmark}% remember last \mark for running header
   \edef\t@st{\p@gefirstmark}%
   \ifx\t@st\empty\xdef\p@gefirstmark{\firstmark}\fi % remember first, if not already set
@@ -207,7 +207,7 @@
   % and check if it all fit; if not, we'll have to back up and try again
   \ifvoid255 \fitonpagetrue \else \fitonpagefalse \fi
   \iffitonpage
-%%%    \msg{SUCCEEDED, shipping page}
+%%%    \msg{1 SUCCEEDED, shipping page hIns=\the\holdinginserts}
 % at this point:
 %   \box\colA is the page content
 %   \availht is ht that definitely works
@@ -237,7 +237,7 @@
     \else\global\output={\onecol}\fi
   \else % the contents of the "galley" didn't fit into the actual page,
         % so reduce \vsize and try again with an earlier break
-%%%    \msg{REDUCING VSIZE}
+%%%    \msg{1c REDUCING VSIZE hIns=\the\holdinginserts}
     \global\advance\vsize by -\baselineskip
     \global\setbox\topins=\box\voidb@x
     \global\setbox\bottomins=\box\voidb@x
@@ -294,6 +294,7 @@
   \fi}
 
 \newif\iff@rstnote
+\f@rstnotetrue
 \def\footnoterule{\kern-0.5\AboveNoteSpace\kern-.4pt % the \hrule is .4pt high
   \dimen0=\textwidth\advance\dimen0 by -\columnshift\toks0=\everypar\everypar={}\parskip=0pt\baselineskip=0pt\parindent=0pt\let\par=\endgraf\parfillskip=0pt%
 %  \noindent\hbox{\noindent\kern\columnshift\vbox{\hrule width \dimen0}}\par
@@ -431,7 +432,8 @@
   % and check if it all fit; if not, we'll have to back up and try again
   \ifvoid255 \fitonpagetrue \else \fitonpagefalse \fi
   \iffitonpage
-%%%    \msg{SUCCEEDED, shipping page}
+%%%    %FIXME? savepartialpage gets called with holdinginserts=1, but this bit seems written assuming holdinginserts=0.
+    %%%\msg{spp SUCCEEDED, 'shipping' page to partial. hIns=\the\holdinginserts}
 % at this point:
 %   \box\colA is the page content
 %   \availht is ht that definitely works
@@ -459,7 +461,7 @@
     \global\holdinginserts=1
   \else % the contents of the "galley" didn't fit into the actual page,
         % so reduce \vsize and try again with an earlier break
-%%%    \msg{REDUCING VSIZE}
+%%%    \msg{2c REDUCING VSIZE hIns=\the\holdinginserts}
     \global\advance\vsize by -\baselineskip
     \global\setbox\topins=\box\voidb@x
     \global\setbox\bottomins=\box\voidb@x
@@ -476,7 +478,7 @@
 
 
 \def\twocols{% primary output routine in 2-col mode
-%%%  \msg{TWOCOLS @ \ch@pter:\v@rse, txtht=\the\textheight, partial=\the\ht\partial}
+%%%  \msg{TWOCOLS @ \ch@pter:\v@rse, txtht=\the\textheight, partial=\the\ht\partial, hIns=\the\holdinginserts}
   % save copy of current page so we can retry with different heights
   \global\setbox\galley=\copy255
   \global\galleypenalty=\outputpenalty % save current penalty so we can restore it at (A)
@@ -594,7 +596,7 @@
   \ifvoid255 \fitonpagetrue \else \fitonpagefalse \fi
 %%%  \msg{first col = \the\ht\colA, second col = \the\ht\colB, rem = \the\ht255}
   \iffitonpage
-    %\msg{SUCCEEDED, shipping page}
+    %\msg{sppd SUCCEEDED, shipping page hIns=\the\holdinginserts}
     % re-split to better balance columns, if possible
     % at this point:
     %   \box\colA + \box\colB is the page content
@@ -625,7 +627,7 @@
     \advance\dimen3 by \dimen4 \ht\partial=\dimen3
     \global\holdinginserts=1
   \else
-%%%    \msg{SAVEPARTIALPAGED Backingup remainder=\the\ht255, total=\the\ht\s@vedpage, vsize=\the\vsize, baselineskip=\the\baselineskip}%
+%%%    \msg{SAVEPARTIALPAGED Backingup remainder=\the\ht255, total=\the\ht\s@vedpage, vsize=\the\vsize, baselineskip=\the\baselineskip, hIns=\the\holdinginserts}%
     \global\advance\vsize by -\baselineskip
     \global\setbox\topins=\box\voidb@x
     \global\setbox\bottomins=\box\voidb@x
@@ -644,7 +646,7 @@
 }
 
 \def\twocoltrial{% trial formatting to see if current contents will fit on the page
-%%%\msg{TRIAL with ht=\the\trialheight, vsize=\the\vsize}
+%%%\msg{2c TRIAL with ht=\the\trialheight, vsize=\the\vsize, hIns=\the\holdinginserts}
   \edef\p@gebotmark{\botmark}% remember last \mark for running header
   \edef\t@st{\p@gefirstmark}%
   \ifx\t@st\empty\edef\p@gefirstmark{\firstmark}\fi % remember first, if not already set
@@ -668,9 +670,9 @@
   %\setbox\colB=\vbox{\unvbox\colB}
   % and check if it all fit; if not, we'll have to back up and try again
   \ifvoid255 \fitonpagetrue \else \fitonpagefalse \fi
-%%%  \msg{first col = \the\ht\colA, second col = \the\ht\colB, rem = \the\ht255}
+%%%  \msg{first col = \the\ht\colA, second col = \the\ht\colB, rem = \the\ht255, hIns=\the\holdinginserts}
   \iffitonpage
-    %\msg{SUCCEEDED, shipping page}
+    %\msg{2 SUCCEEDED, shipping page}
     % re-split to better balance columns, if possible
     % at this point:
     %   \box\colA + \box\colB is the page content
@@ -721,7 +723,7 @@
     \else\global\output={\twocols}\fi
   \else % the contents of the "galley" didn't fit into the columns,
         % so reduce \vsize and try again with an earlier break
-%%%    \msg{REDUCING VSIZE}
+%%%    \msg{2c REDUCING VSIZE hIns=\the\holdinginserts}
     \global\advance\vsize by -\baselineskip
 	% clear insertions
     \global\setbox\topins=\box\voidb@x
@@ -758,7 +760,7 @@
 
 \def\backingup{% this output routine is used when we reduce \vsize;
                % it will cause a new page break to be found, and then the \trial routine is called again
-%%%  \msg{BACKING-UP}
+%%%  \msg{BACKING-UP hIns=\the\holdinginserts(==1)}
   \global\deadcycles=0
   \global\setbox\galley=\copy255
   \global\galleypenalty=\outputpenalty
@@ -770,22 +772,42 @@
 
 \xdef\p@gefirstmark{}
 
+\def\savepartialpagedbounce{
+  %This output routine gets the partial galley (input text) before a 2->1 column transition so that it can be re-run with holdinginserts=0, so footnotes etc can be seen.
+  \msg{sppb hIns=\the\holdinginserts, \the\ht\partial, \the\ht255, }
+  \global\holdinginserts=0
+  \global\output={\savepartialpaged}
+  \global\setbox\galley=\copy255
+  \unvbox255\eject
+}
 % to switch back to single column, we reset the page size parameters
 \def\singlecolumn{%
   \ifnum\c@rrentcols>1
     \ifhe@dings\endhe@dings\fi
-    \global\holdinginserts=0
-    \global\output={\savepartialpaged}\eject % save any partially-full page
+    \global\output={\savepartialpagedbounce}\eject % save any partially-full page into a box
     \global\hsize=\textwidth \advance\hsize by -\columnshift
     \global\vsize=\textheight
-    \global\c@rrentcols=1
-%%%      \MSG{\the\ht\partial is > 0.9 times \the\textheight?}
-    \global\output={\onecol}
     \ifdim\ht\partial>0.9\textheight
-      \unvbox\partial\vfill\eject
+%%%      \MSG{\the\ht\partial is > 0.9 times \the\textheight}
+      \def\pagecontents{%really ship out the page, there's no more space
+        \vbox{\dimen1=\textwidth \advance\dimen1 \ExtraRMargin
+        \ifvoid\partial\else \vbox{\hbox to \dimen1{\hskip\columnshift\box\partial}} \fi
+        %\unvbox\bottomins
+	\dimen0=\dp\partial
+        \ifvoid\bottomins\else \kern-\dimen0 \dimen0=0pt \vskip\skip\bottomins \unvbox\bottomins \fi % ouput bottom spanning pictures
+	 \let\\=\ins@rtn@tecl@ss \the\n@tecl@sses % output all note classes
+         \iff@rstnote % no notes actually occurred!
+           \kern-\dimen0 \vfil
+         \else
+           \setbox0=\lastbox \dimen0=\dp0 \box0 \kern-\dimen0
+         \fi
+      }}\plainoutput
+      %\vbox to \textheight{\unvbox\partial\vfil\bottomins}\eject
     %\else
       %\penalty-100\vskip\baselineskip % ensure blank line between single and double column material
     \fi
+    \global\c@rrentcols=1
+    \global\output={\onecol}
     \global\holdinginserts=1
     \count255=1000
     \global\count\topins=\count255


### PR DESCRIPTION
Hi,
 I think I've figured out the issue with short books, with  footnotes vanishing. It took a lot of hunting. In the end the key bit was the code around line 785, regarding what it does when >90% of the page is full.  I'm **pretty sure** the rest of my changes are needed.
DJG