### PR TITLE
fix trialheight-related footnote error

### DIFF
--- a/src/paratext2.tex
+++ b/src/paratext2.tex
@@ -643,7 +643,7 @@
   \ifx\t@st\empty\xdef\p@gefirstmark{\firstmark}\fi % remember first, if not already set
   \edef\t@st{\p@gebotmark}%
   \ifx\t@st\empty\xdef\p@gebotmark{\botmark}\fi%
-  \global\trialheight=\textheight
+  \global\trialheight=\textheight \global\advance\trialheight by -\ht\partial
   \availht=\trialheight % amount of space we think is available
   \f@rstnotetrue
   \let\\=\reduceavailht \the\n@tecl@sses % reduce it by the space needed for each note class


### PR DESCRIPTION
incorrect trialheight redefinition was pushing some footnotes off bottom of page... just perfectly in my test case so it looked like they were evaporating for another reason. One line of code after 8+ hours of looking down all the wrong rabbit holes...