### PR TITLE
Change local FRT to use .SFM instead of .tex

### DIFF
--- a/python/lib/ptxprint/runjob.py
+++ b/python/lib/ptxprint/runjob.py
@@ -592,7 +592,7 @@ class RunJob:
         outfname = info.printer.baseTeXPDFnames([r[0][0].first.book if r[1] else r[0] for r in jobs])[0] + ".tex"
         info.update()
         if info['project/iffrontmatter'] != '%':
-            frtfname = os.path.join(self.tmpdir, outfname.replace(".tex", "_FRT.tex"))
+            frtfname = os.path.join(self.tmpdir, outfname.replace(".tex", "_FRT.SFM"))
             info.createFrontMatter(frtfname)
             genfiles.append(frtfname)
         logger.debug("diglot styfile is {}".format(info['diglot/ptxprintstyfile_']))

--- a/python/lib/ptxprint/view.py
+++ b/python/lib/ptxprint/view.py
@@ -1653,7 +1653,7 @@ class ViewModel:
         zf.writestr("{}/fonts.conf".format(self.prjid), writefontsconf(archivedir=True))
         scriptlines = ["#!/bin/sh", "cd local/ptxprint/{}".format(self.configName())]
         for t in texfiles:
-            if t.endswith("_FRT.tex"):
+            if t.endswith("_FRT.SFM"):
                 continue
             scriptlines.append("hyph_size=32749 stack_size=32768 FONTCONFIG_FILE=`pwd`/../../../fonts.conf TEXINPUTS=../../../src:. xetex {}".format(os.path.basename(t)))
         zinfo = ZipInfo("{}/runtex.sh".format(self.prjid))
@@ -1671,7 +1671,7 @@ set TEXINPUTS=.;%cd%\\..\\..\\..\\src\\;
 set hyph_size=32749
 set stack_size=32768""".format(self.configName())
         for t in texfiles:
-            if t.endswith("_FRT.tex"):
+            if t.endswith("_FRT.SFM"):
                 continue
             batfile += '\nif exist "%truetex%" "%truetex%" {}\ncd ..\..\..'.format(os.path.basename(t))
         zf.writestr("{}/runtex.txt".format(self.prjid), batfile)


### PR DESCRIPTION
Currently the _FRT file in the local directory has a .tex file, but when you look in it, the actual contents are sfm. This caused me confusion when I was looking for this file.