### PR TITLE
fix: duplicate widget_map key and Log Analysis excluded from HTML summary

### DIFF
--- a/python/lib/ptxprint/report.py
+++ b/python/lib/ptxprint/report.py
@@ -365,7 +365,6 @@ class Report:
             "Front Matter PDF(s)":        ("7. Peripheral Components", "c_inclFrontMatter", 0, \
                                             lambda v,w: (v.get("lb"+w[1:], "").strip("."), logging.DEBUG)),
             "Table of Contents":          ("7. Peripheral Components", "c_autoToC", 0, None),
-            "Thumb Tabs":                 ("6. Features", "c_thumbtabs", 0, None),
             "Front Matter":               ("7. Peripheral Components", "c_frontmatter", 0, \
                                             lambda v,w: ("", logging.WARN if v.get(w, False) and v.get("c_colophon", False) else logging.DEBUG)),
             "Colophon":                   ("7. Peripheral Components", "c_colophon", 0, \
@@ -671,7 +670,7 @@ class Report:
         Calculates the max severity for each main section and generates an HTML summary line
         with clickable blocks.
         """
-        max_severities = {i: logging.NOTSET for i in range(1, 10)}
+        max_severities = {i: logging.NOTSET for i in range(1, 11)}
         for section_key, entries in self.sections.items():
             if not entries:
                 continue
@@ -686,7 +685,7 @@ class Report:
             if current_max_severity > max_severities[main_section_num]:
                 max_severities[main_section_num] = current_max_severity
         summary_blocks = []
-        for i in range(1, 10):
+        for i in range(1, 11):
             severity = max_severities[i]
             color_index = severity // 10
             color = logcolors[color_index]
@@ -754,7 +753,7 @@ class Report:
         return findings
 
     def get_log_analysis(self, view, log_content_string):
-        section_base = "Log File Analysis"
+        section_base = "10. Log File Analysis"
         if not log_content_string or not log_content_string.strip():
             self.add(section_base, "Log file content not available or empty.", severity=logging.WARN); return
         findings = self._analyze_log_file_content(log_content_string)


### PR DESCRIPTION
## Summary

- Fixes a duplicate `\"Thumb Tabs\"` key in the `widget_map` dictionary in `report.py` (bug 01)
- Fixes the Log File Analysis section being silently omitted from the HTML report summary bar (bug 05)

---

## Bug 01 — Duplicate `\"Thumb Tabs\"` key in `widget_map`

### What is broken

`widget_map` in `get_general_info` (`report.py`) contains two entries with the key `\"Thumb Tabs\"` — one at line 345 and an identical one at line 368. Python silently discards the first entry when it encounters the duplicate; the widget mapped on line 345 is permanently unreachable via `widget_map`.

### Why it matters

Any feature that looks up `\"Thumb Tabs\"` in `widget_map` silently uses the wrong (last-defined) entry, or misses the first entirely. This is a copy-paste oversight that could hide a real mapping error if the two entries ever diverged.

### How it was fixed

Removed the redundant second `\"Thumb Tabs\"` entry (line 368). The first entry (line 345) is retained unchanged.

---

## Bug 05 — Log File Analysis section excluded from HTML summary bar

### What is broken

`get_log_analysis` sets `section_base = \"Log File Analysis\"` — a string that does **not** start with a digit. `_generate_summary_html` only processes sections whose names parse as integers in `range(1, 10)`, so the Log Analysis section is collected but never rendered in the clickable summary bar at the top of the HTML report.

### Why it matters

Log analysis data (parse errors, rerun warnings, etc.) is gathered on every run but silently excluded from the summary. Users have no visual indicator in the summary that log analysis results exist or that there are warnings/errors there.

### How it was fixed

1. Renamed `section_base` from `\"Log File Analysis\"` to `\"10. Log File Analysis\"` so it sorts and parses correctly alongside the other numbered sections.
2. Extended the `range(1, 10)` in `_generate_summary_html` to `range(1, 11)` in both the `max_severities` initialisation dict and the summary-block rendering loop, so section 10 is included.

---

## Files changed

- `python/lib/ptxprint/report.py`

## Bug reports

`bugs/python/bug-01-duplicate-widget-map-key/` and `bugs/python/bug-05-log-analysis-section/` (local only, not committed)