### PR TITLE
fix: dead code after return and unused variable in report.py

### DIFF
--- a/python/lib/ptxprint/report.py
+++ b/python/lib/ptxprint/report.py
@@ -323,9 +323,6 @@ class Report:
             return False
         return True
 
-        def myhackylambda(view, widget):
-            return ("", logging.DEBUG)
-
     def get_general_info(self, view):
         widget_map = {
             "Project Name":               ("1. Project/Overview", "l_projectFullName", 1100, \
@@ -373,8 +370,6 @@ class Report:
             "Back Matter PDF(s)":         ("7. Peripheral Components", "c_inclBackMatter", 0, \
                                             lambda v,w: (v.get("lb"+w[1:], "").strip("."), logging.DEBUG)),
         }
-        
-        check_order = 100  # Not used, consider removing or integrating
         
         for title, (section, widget_id, order, widget_fn) in widget_map.items():
             if not view.get(widget_id, False):


### PR DESCRIPTION
## Summary

- Removes unreachable dead code (`myhackylambda`) defined after a `return` statement in `get_usfm` (bug 02)
- Removes an unused variable `check_order` that was already flagged with a comment saying it was not used (bug 04)

---

## Bug 02 — Dead code after `return True` in `get_usfm`

### What is broken

In `get_usfm` (`report.py`), after `return True` on line 324 a nested function `myhackylambda(view, widget)` is defined. Python never executes any code after a `return`, so this function is completely unreachable dead code.

### Why it matters

Unreachable code after a `return` is almost always a logic error — either the function was meant to use `myhackylambda` before returning, or it was left behind after a refactor. As written it obscures intent and will never be executed regardless of any code path.

### How it was fixed

Removed the two dead lines (`def myhackylambda` and its `return` body). The function had no call sites anywhere in the codebase, confirming it is genuinely unused.

---

## Bug 04 — Unused variable `check_order`

### What is broken

In `get_general_info` (`report.py`), the line `check_order = 100` assigns a value that is never subsequently read. The inline comment in the source already said *"Not used, consider removing or integrating"*.

### Why it matters

Dead assignments are clutter that misleads readers into thinking the variable does something. The comment confirming it is unused makes this a clear candidate for removal.

### How it was fixed

Deleted the `check_order = 100` line and its trailing blank line.

---

## Files changed

- `python/lib/ptxprint/report.py`

## Bug reports

`bugs/python/bug-02-dead-code-after-return/` and `bugs/python/bug-04-unused-check-order/` (local only, not committed)