### PR TITLE
fix: essential-markers check in get_usfm never called

### DIFF
--- a/python/lib/ptxprint/report.py
+++ b/python/lib/ptxprint/report.py
@@ -288,6 +288,7 @@ class Report:
                         msg = f"{ref} {msg} at line {pos.l + 1}, char {pos.c + 1}"
                     failed.setdefault(bk, []).append(msg)
             else:
+                self.get_usfm(view, doc, bk)
                 errors = doc.runchecks()
                 if len(errors):
                     for e in errors:


### PR DESCRIPTION
## Summary

- Fixes `get_usfm`'s essential-markers check (`h toc1 toc2 toc3 p`) being dead code — it was never invoked during a normal run (`report.py`)

---

## Bug 03 — `get_usfm` essential-markers check never runs

### What is broken

`run_view` calls `get_usfms` (plural). `get_usfms` iterates over all books and runs schema checks via `doc.runchecks()`, but it **never calls** `get_usfm` (singular). `get_usfm` contains a dedicated check for essential USFM markers (`h`, `toc1`, `toc2`, `toc3`, `p`) that books must contain to typeset correctly. Because `get_usfms` does not call `get_usfm`, this entire validation block is dead code and never executes.

### Why it matters

Books can be sent to the typesetter without any validation that required structural markers are present. A book missing `\h` or `\p` would be silently accepted and likely produce confusing or broken PDF output, with no early warning to the user about the missing markers.

### How it was fixed

Added a call to `self.get_usfm(view, doc, bk)` inside the `else` branch of `get_usfms` (the branch reached when the book parses without XML errors), before `doc.runchecks()`. This activates the existing essential-markers check without duplicating any logic or changing the flow for books that do have parse errors.

---

## Files changed

- `python/lib/ptxprint/report.py`

## Bug report

`bugs/python/bug-03-get-usfm-never-called/` (local only, not committed)