### PR TITLE
fix: doError logs primary message twice instead of logging secondary

### DIFF
--- a/python/lib/ptxprint/view.py
+++ b/python/lib/ptxprint/view.py
@@ -63,7 +63,7 @@ def doError(txt, secondary=None, **kw):
     logger.error(txt)
     if secondary is not None:
         print(secondary)
-        logger.error(txt)
+        logger.error(secondary)
 
 class ViewModel:
     _attributes = {


### PR DESCRIPTION
## Summary

- Fixes the module-level `doError` function logging `txt` (the primary message) a second time instead of logging `secondary` (`view.py`)

---

## Bug 06 — `doError` logs `txt` instead of `secondary`

### What is broken

The module-level `doError(txt, secondary=None)` function in `view.py`:

```python
def doError(txt, secondary=None, **kw):
    print(txt)
    logger.error(txt)
    if secondary is not None:
        print(secondary)
        logger.error(txt)   # ← should be logger.error(secondary)
```

When a secondary message is provided it is correctly printed to stdout, but `logger.error` is called with `txt` again instead of `secondary`. The secondary detail is therefore never written to the log file.

### Why it matters

Secondary messages typically contain the detailed explanation of an error (e.g. the specific file path, the exception text, or the diagnostic detail). When debugging from log files, this context is silently missing, making it significantly harder to diagnose failures without also having access to the terminal output.

### How it was fixed

Changed the second `logger.error(txt)` call to `logger.error(secondary)`.

---

## Files changed

- `python/lib/ptxprint/view.py`

## Bug report

`bugs/python/bug-06-doerror-logs-wrong-var/` (local only, not committed)