### PR TITLE
fix: getBooks returns None instead of [] when no project is loaded

### DIFF
--- a/python/lib/ptxprint/view.py
+++ b/python/lib/ptxprint/view.py
@@ -291,7 +291,7 @@ class ViewModel:
 
     def getBooks(self, scope=None, files=False, local=False):
         if self.project is None:
-            return
+            return []
         if scope is None:
             scope = self.get("r_book")
         if scope == "module":


### PR DESCRIPTION
## Summary

- Fixes `getBooks` returning `None` (via a bare `return`) instead of an empty list `[]` when `self.project is None` (`view.py`)

---

## Bug 07 — `getBooks` returns `None` instead of `[]`

### What is broken

```python
def getBooks(self, scope=None, files=False, local=False):
    if self.project is None:
        return        # ← returns None implicitly
```

When no project is loaded, `getBooks` hits a bare `return`, giving the caller `None`. Every call site that iterates the result — e.g. `for book in self.getBooks():` — will immediately raise:

```
TypeError: 'NoneType' object is not iterable
```

### Why it matters

`getBooks` is called from many places in the codebase. Any code path that calls it before a project is loaded (e.g. during startup, when switching projects, or in error-recovery paths) will crash with an unhandled `TypeError` rather than gracefully doing nothing. This makes PTXprint fragile in any scenario where the project is transiently unset.

### How it was fixed

Changed `return` to `return []`. An empty list is the correct sentinel meaning "no books" and is safe to iterate over, pass to `len()`, or otherwise consume without a guard.

---

## Files changed

- `python/lib/ptxprint/view.py`

## Bug report

`bugs/python/bug-07-getbooks-returns-none/` (local only, not committed)