### PR TITLE
fix: path typo shard->shared and _mergecfg reads wrong config object

### DIFF
--- a/python/lib/ptxprint/view.py
+++ b/python/lib/ptxprint/view.py
@@ -641,8 +641,8 @@ class ViewModel:
             if new.has_section(sect):
                 allopts.update(new.options(sect))
             for opt in allopts:
-                if config.has_option(sect, opt) and (not base.has_option(sect, opt)
-                        or config.get(sect, opt) != base.get(sect, opt)):
+                if this.has_option(sect, opt) and (not base.has_option(sect, opt)
+                        or this.get(sect, opt) != base.get(sect, opt)):
                     continue
                 if new.has_option(sect, opt):
                     this.set(sect, opt, new.get(sect, opt))
@@ -848,7 +848,7 @@ class ViewModel:
             return self.copyrightInfo
         with open(os.path.join(pycodedir(), "picCopyrights.json"), encoding="utf-8", errors="ignore") as inf:
             self.copyrightInfo = json.load(inf)
-        fname = os.path.join(self.project.path, "shard", "ptxprint", "picCopyrights.json")
+        fname = os.path.join(self.project.path, "shared", "ptxprint", "picCopyrights.json")
         if os.path.exists(fname):
             with open(fname, encoding="utf-8", errors="ignore") as inf:
                 try:


### PR DESCRIPTION
## Summary

- Fixes a path typo `"shard"` → `"shared"` that silently prevented per-project picture-copyright overrides from loading (bug 08)
- Fixes `_mergecfg` reading options from the wrong `ConfigParser` object, causing the merge logic to never skip user-customised options (bug 09)

---

## Bug 08 — Path typo `"shard"` should be `"shared"`

### What is broken

```python
fname = os.path.join(self.project.path, "shard", "ptxprint", "picCopyrights.json")
```

The directory component `"shard"` is a typo for `"shared"`. The path will never exist on disk, so the per-project picture-copyright override file is silently never loaded on any run.

### Why it matters

Users who place custom picture copyright data in `shared/ptxprint/picCopyrights.json` will find their overrides are completely ignored every time, with no error or warning. This is a silent data-loss bug.

### How it was fixed

Changed `"shard"` to `"shared"`.

---

## Bug 09 — `_mergecfg` uses wrong `config` variable

### What is broken

Inside `_mergecfg`, three `ConfigParser` objects are loaded from disk and unpacked:

```python
for a in (destp, srcp, mergep):
    config = configparser.ConfigParser(...)
    ...
    configs.append(config)
(this, new, base) = configs
```

After the loop `config` holds the last value assigned — the parser for `mergep`, i.e. `base`. The guard condition on line 644 then reads:

```python
if config.has_option(sect, opt) and (not base.has_option(sect, opt)
        or config.get(sect, opt) != base.get(sect, opt)):
    continue
```

Since `config` **is** `base`, this simplifies to `base.has_option(...) and False`, which is always `False`. The `continue` is therefore never executed: user customisations in `this` are never protected from being overwritten by `new`.

### Why it matters

The purpose of `_mergecfg` is to merge a new config into the destination while preserving options the user has already customised relative to the base. Because the guard never fires, every option in `new` unconditionally overwrites `this`, discarding user customisations silently on every merge.

### How it was fixed

Changed `config.has_option` to `this.has_option` and `config.get` to `this.get`, so the guard correctly compares the destination config against the base.

---

## Files changed

- `python/lib/ptxprint/view.py`

## Bug reports

`bugs/python/bug-08-typo-shard-shared/` and `bugs/python/bug-09-mergecfg-wrong-var/` (local only, not committed)