### PR TITLE
fix: analyse_script can crash or loop forever

### DIFF
--- a/python/lib/ptxprint/view.py
+++ b/python/lib/ptxprint/view.py
@@ -802,7 +802,11 @@ class ViewModel:
         bk = None
         while res is None:
             bk = pts.getABook(bk)
+            if bk is None:
+                break
             abook = self.get_usfm(bk)
+            if abook is None:
+                continue
             res = abook.findScript()
         return res
 


### PR DESCRIPTION
## Summary

- Fixes two defects in `analyse_script` that could cause an `AttributeError` crash or an infinite loop (`view.py`)

---

## Bug 10 — `analyse_script` can crash or loop forever

### What is broken

```python
def analyse_script(self):
    pts = self._getPtSettings()
    res = None
    bk = None
    while res is None:
        bk = pts.getABook(bk)
        abook = self.get_usfm(bk)
        res = abook.findScript()   # ← crashes if abook is None
    return res
```

Two problems:

**1. `get_usfm` can return `None`** — if the USFM file has a `SyntaxError`, `get_usfm` catches the exception and returns `None`. Calling `None.findScript()` immediately raises `AttributeError`, crashing the script-analysis path with an unhelpful traceback.

**2. `getABook` can exhaust all books** — `getABook(bk)` walks forward through `allbooks` looking for the next book that exists on disk. When it reaches the end of the list with no match it returns `None` implicitly. The loop condition only checks `res is None`, so it will loop forever calling `getABook(None)` repeatedly (which restarts from the beginning each time), hanging the application.

### Why it matters

Any project whose first parseable book has a syntax error will hang PTXprint indefinitely. A project with no books on disk at all will also hang. In both cases there is no error message and the UI becomes unresponsive.

### How it was fixed

Added two guards inside the loop:

1. After `getABook`: `if bk is None: break` — exits cleanly when all books have been exhausted without finding a usable script.
2. After `get_usfm`: `if abook is None: continue` — skips books that fail to parse (syntax error) and tries the next book instead of crashing.

---

## Files changed

- `python/lib/ptxprint/view.py`

## Bug report

`bugs/python/bug-10-analyse-script-loop/` (local only, not committed)