### PR TITLE
fix: PDF color-variant suffix silently dropped from output filename

### DIFF
--- a/python/lib/ptxprint/runjob.py
+++ b/python/lib/ptxprint/runjob.py
@@ -555,7 +555,7 @@ class RunJob:
         outpath = os.path.join(self.tmpdir, '..', self.outfname[:-4])
         pdfext = _outputPDFtypes.get(self.printer.get("fcb_outputFormat", "")) or ""
         pdfext = "_" + pdfext if len(pdfext) else ""
-        self.pdffile = outpath + ".pdf".format(pdfext)
+        self.pdffile = outpath + f"{pdfext}.pdf"
         logger.debug(f"{self.pdffile} exists({os.path.exists(self.pdffile)})")
         oldversions = int(self.printer.get('s_keepVersions', '0'))
         if oldversions > 0:


### PR DESCRIPTION
## Summary

- Fixes a misplaced `.format()` call that caused the PDF color-variant suffix (e.g. `_CMYK`, `_RGB`) to always be silently dropped from the output filename (`runjob.py`)

---

## Bug 11 — PDF variant suffix silently dropped from filename

### What is broken

```python
self.pdffile = outpath + ".pdf".format(pdfext)
```

`.format(pdfext)` is called on the *literal string* `".pdf"`, which contains no `{}` placeholder. `pdfext` (e.g. `"_CMYK"` or `"_RGB"`) is therefore silently discarded and the output is always just `outpath + ".pdf"` with no variant suffix, regardless of the selected output format.

### Why it matters

When users export in a specific color format (CMYK for print, RGB for screen), all variants write to the **same filename**. Each successive export silently overwrites the previous one. Users who expect distinct files per format — e.g. `document_CMYK.pdf` and `document_RGB.pdf` — instead get a single `document.pdf` containing only whichever variant was run last, with no warning.

### How it was fixed

Changed to an f-string that correctly inserts `pdfext` before `.pdf`:

```python
self.pdffile = outpath + f"{pdfext}.pdf"
```

When `pdfext` is empty (default, no variant), the result is unchanged (`outpath + ".pdf"`). When a variant is active the suffix is correctly included.

---

## Files changed

- `python/lib/ptxprint/runjob.py`

## Bug report

`bugs/python/bug-11-pdffile-format-string/` (local only, not committed)