### PR TITLE
fix: NameError on bare runner in run_xetex and xdvtopdf

### DIFF
--- a/python/lib/ptxprint/runjob.py
+++ b/python/lib/ptxprint/runjob.py
@@ -630,7 +630,7 @@ class RunJob:
             if self.silent:
                 callkw['stdout'] = subprocess.DEVNULL
             self.runner = call(cmd + [action], cwd=self.tmpdir, **callkw)
-            if isinstance(self.runner, subprocess.Popen) and runner is not None:
+            if isinstance(self.runner, subprocess.Popen) and self.runner is not None:
                 try:
                     #runner.wait(self.args.timeout)
                     self.runner.wait()
@@ -721,7 +721,7 @@ class RunJob:
             except subprocess.TimeoutExpired:
                 print("Timed out!")
             self.res = 4 if self.runner.returncode else 0
-            logger.debug(f"{runner.stdout.decode('UTF-8')}")
+            logger.debug(f"{self.runner.stdout.decode('UTF-8')}")
         elif isinstance(self.runner, subprocess.CompletedProcess):
             self.res = 4 if self.runner.returncode else 0
             logger.debug(f"{self.runner.stdout}")


### PR DESCRIPTION
## Summary

- Fixes a `NameError` on `runner` (should be `self.runner`) in the process-cleanup path of `run_xetex` (bug 12)
- Fixes a `NameError` on `runner` (should be `self.runner`) in the stdout-logging line of `xdvtopdf` (bug 13)

Both are in `runjob.py`.

---

## Bug 12 — `runner` NameError in `run_xetex`

### What is broken

```python
self.runner = call(cmd + [action], ...)
if isinstance(self.runner, subprocess.Popen) and runner is not None:
```

`runner` (without `self.`) is not defined in this scope. Python will raise `NameError: name 'runner' is not defined` when the `isinstance` check on `self.runner` is `True` and the code tries to evaluate `runner is not None`.

### Why it matters

The entire process-cleanup path for a long-running XeTeX subprocess — waiting for it to finish and collecting its return code — crashes with a `NameError` instead of completing. The subprocess may be left running or its exit code lost.

### How it was fixed

Changed `runner is not None` to `self.runner is not None`.

---

## Bug 13 — `runner` NameError in `xdvtopdf`

### What is broken

```python
logger.debug(f"{runner.stdout.decode('UTF-8')}")
```

Same problem: `runner` is not defined in `xdvtopdf`'s scope. The correct reference is `self.runner`.

### Why it matters

The debug log line that captures XDV-to-PDF conversion stdout raises `NameError` instead of logging, making it impossible to see this output even when debug logging is enabled.

### How it was fixed

Changed `runner.stdout` to `self.runner.stdout`.

---

## Files changed

- `python/lib/ptxprint/runjob.py`

## Bug reports

`bugs/python/bug-12-runner-nameerror-xetex/` and `bugs/python/bug-13-runner-nameerror-xdvtopdf/` (local only, not committed)