### PR TITLE
fix: bare except: in parselog swallows KeyboardInterrupt and SystemExit

### DIFF
--- a/python/lib/ptxprint/runjob.py
+++ b/python/lib/ptxprint/runjob.py
@@ -889,7 +889,7 @@ class RunJob:
                     loglines.append(l)
                     if len(loglines) > lines:
                         loglines.pop(0)
-        except:
+        except Exception:
             loglines.append("Logfile missing: "+fname)
         return (loglines, rerunres)
 


### PR DESCRIPTION
## Summary

- Replaces a bare `except:` with `except Exception:` in `parselog` to avoid silently swallowing `KeyboardInterrupt` and `SystemExit` (`runjob.py`)

---

## Bug 14 — Bare `except:` in `parselog`

### What is broken

```python
try:
    ...   # read and parse the TeX log file
except:
    loglines.append("Logfile missing: " + fname)
```

A bare `except:` catches **all** exceptions including `BaseException` subclasses such as `KeyboardInterrupt` (Ctrl-C) and `SystemExit`. These signals are intended to stop the process but are silently absorbed here.

### Why it matters

If the user presses Ctrl-C while PTXprint is reading the log file, the interrupt is swallowed. The application appears to hang or ignore the interrupt rather than responding to it. `SystemExit` (e.g. from `sys.exit()`) is similarly absorbed, preventing clean shutdown.

### How it was fixed

Changed `except:` to `except Exception:`. `Exception` is the base class for all ordinary runtime errors but does **not** catch `KeyboardInterrupt`, `SystemExit`, or `GeneratorExit`, so those signals are correctly propagated.

---

## Files changed

- `python/lib/ptxprint/runjob.py`

## Bug report

`bugs/python/bug-14-bare-except-parselog/` (local only, not committed)