### PR TITLE
fix: diginfo used after loop ends — NameError when diginfos is empty

### DIFF
--- a/python/lib/ptxprint/runjob.py
+++ b/python/lib/ptxprint/runjob.py
@@ -445,8 +445,10 @@ class RunJob:
         logger.debug(f"{donebooks=}")
 
         # Pass all the needed parameters for the snippet from diginfo to info
-        for k,v in _diglotprinter.items():
-            self.info.printer.set(k, diginfo.printer.get(v))
+        if diginfos:
+            _diginfo = next(iter(diginfos.values()))
+            for k,v in _diglotprinter.items():
+                self.info.printer.set(k, _diginfo.printer.get(v))
         self.info["_isDiglot"] = True
         res = self.sharedjob(jobs, diglots=True)
         texfiles += res


### PR DESCRIPTION
## Summary

- Fixes `diginfo` and `k` being referenced after their defining loop, causing a `NameError` when `diginfos` is empty, in `digdojob` (`runjob.py`)

---

## Bug 15 — `diginfo` used after loop ends

### What is broken

```python
for k, diginfo in diginfos.items():
    ...   # per-book diglot processing

# Pass all the needed parameters for the snippet from diginfo to info
for k, v in _diglotprinter.items():
    self.info.printer.set(k, diginfo.printer.get(v))   # ← diginfo from outer loop
```

After the `for k, diginfo in diginfos.items()` loop, `diginfo` holds the last value from that loop as a loop residual. Two problems:

1. **`NameError` when `diginfos` is empty** — if there are no diglot projects, `diginfo` was never assigned, so the reference on the last line raises `NameError: name 'diginfo' is not defined`.
2. **Wrong value when multiple diglot projects exist** — the code intends to copy printer settings from *a* diglot project into `self.info`, but accidentally uses whatever happened to be the last `diginfo` from the loop rather than an explicitly chosen one.

### Why it matters

Any diglot job where the diglot project list is transiently empty (e.g. during initialisation or after a project removal) will crash with an unhandled `NameError` instead of silently doing nothing.

### How it was fixed

Added an `if diginfos:` guard and explicitly fetched the first diglot project with `next(iter(diginfos.values()))` into a local `_diginfo`, making the intent clear and eliminating both the `NameError` and the implicit dependency on loop-residual state.

---

## Files changed

- `python/lib/ptxprint/runjob.py`

## Bug report

`bugs/python/bug-15-diginfo-after-loop/` (local only, not committed)