### PR TITLE
fix: three bugs in usfmerge.py — globalcl scope, doc undefined, wrong action variable

### DIFF
--- a/python/lib/ptxprint/usfmerge.py
+++ b/python/lib/ptxprint/usfmerge.py
@@ -327,9 +327,9 @@ class Collector:
         return res
 
     def makeChunk(self, c=None):
-        global _validatedhpi, _headingidx
+        global _validatedhpi, _headingidx, globalcl
         if c is None:
-            currChunk = Chunk(mode=self.mode, doc=doc, bk=self.book)
+            currChunk = Chunk(mode=self.mode, doc=self.doc, bk=self.book)
             self.waspar = False
             self.waschap = False
         else:
@@ -766,9 +766,9 @@ def alignChunks(primary, secondary):
                 logger.debug(f"--- {op}, {debstr(pgk[abg:aeg])}, {debstr(sgk[bbg:beg])}")
                 if actiong == "equal":
                     appendpairs(pairs, sum(pgg[abg:aeg], []), sum(sgg[bbg:beg], []))
-                elif action == "delete":
+                elif actiong == "delete":
                     appendpair(pairs, 0, sum(pgg[abg:aeg], []))
-                elif action == "insert":
+                elif actiong == "insert":
                     appendpair(pairs, 0, sum(sgg[bbg:beg], []))
                 elif action == "replace":
                     for zp in zip(range(abg, aeg), range(bbg, beg)):


### PR DESCRIPTION
## Summary

- Fixes `globalcl = True` creating a local variable instead of setting the module-level flag in `makeChunk` (bug 16)
- Fixes `doc` being undefined when `makeChunk` is called with no arguments (bug 17)
- Fixes inner conditionals in `alignChunks` checking `action` (the outer variable) instead of `actiong` (the inner loop variable), making delete/insert sub-operations unreachable (bug 20)

All three are in `python/lib/ptxprint/usfmerge.py`.

---

## Bug 16 — `globalcl = True` creates a local, not a global

### What is broken

Inside `makeChunk`, the assignment `globalcl = True` on line 342 creates a *local* variable because `global globalcl` is not declared at the top of the function. The module-level `globalcl` flag (initialised to `False` at line 237) is never set to `True`.

### Why it matters

`globalcl` tracks whether a `\cl` marker has been seen. Code at line 849 reads `if globalcl:` to gate behaviour that depends on this flag. Because the flag is never set, that branch is permanently dead — even when a `\cl` marker is present.

### How it was fixed

Added `globalcl` to the existing `global` declaration at the top of `makeChunk`:
```python
global _validatedhpi, _headingidx, globalcl
```

---

## Bug 17 — `doc` undefined in `makeChunk(c=None)`

### What is broken

When `makeChunk` is called with no argument (`c is None`), it creates a new `Chunk` using a bare `doc` variable:

```python
currChunk = Chunk(mode=self.mode, doc=doc, bk=self.book)
```

`doc` is not a parameter of `makeChunk` and is not defined in local scope. Python raises `NameError: name 'doc' is not defined`.

### Why it matters

Any call to `makeChunk()` without arguments crashes immediately, making that code path completely unusable.

### How it was fixed

Changed `doc=doc` to `doc=self.doc`. The class stores its document reference as `self.doc` (set in `__init__` at line 310), which is the correct value to pass here.

---

## Bug 20 — Wrong variable `action` vs `actiong` in `alignChunks`

### What is broken

Inside the `elif action == "replace":` outer branch, a second diff is computed over chunk-class groups, yielding `actiong` for each sub-operation:

```python
for opg in diffg.get_opcodes():
    (actiong, abg, aeg, bbg, beg) = opg
    if actiong == "equal":
        ...
    elif action == "delete":    # ← should be actiong
        ...
    elif action == "insert":    # ← should be actiong
        ...
```

The inner `elif` clauses check `action` (the outer variable, which is always `"replace"` in this branch) instead of `actiong`. The `"delete"` and `"insert"` sub-operations can therefore never be reached.

### Why it matters

When aligning chunks in replace mode, individual group-level delete and insert operations are silently skipped. Only the equal and nested-replace sub-cases execute. This produces incorrect chunk alignment for any replace operation that contains group-level deletions or insertions.

### How it was fixed

Changed the two inner `elif action ==` checks to `elif actiong ==`.

---

## Files changed

- `python/lib/ptxprint/usfmerge.py`

## Bug reports

`bugs/python/bug-16-globalcl-missing-global/`, `bugs/python/bug-17-doc-undefined-makechunk/`, and `bugs/python/bug-20-wrong-action-var-alignchunks/` (local only, not committed)