### PR TITLE
fix: self-assignment no-ops and mutable default argument in usfmerge.py

### DIFF
--- a/python/lib/ptxprint/usfmerge.py
+++ b/python/lib/ptxprint/usfmerge.py
@@ -585,8 +585,8 @@ class Collector:
                 if bi is None:
                     bi=i-1
                 logger.log(7, f"Merge.5b: {self.acc[bi].position} , {self.acc[i].position}?")
-                self.acc[i].verse = self.acc[i].verse
-                self.acc[i].pnum = self.acc[i].pnum
+                self.acc[i].verse = self.acc[bi].verse
+                self.acc[i].pnum = self.acc[bi].pnum
                 self.acc[i].insert(0,self.acc[bi][0])
                 #self.acc[bi].syncp = self.acc[i].syncp
                 #self.acc[bi].type = ChunkType.USERSYNC
@@ -651,7 +651,9 @@ class Collector:
             else:
               logger.log(7, f"r: {i}, '-//-', {self.acc[i].type=}, {self.acc[i]=}")
 
-    def score(self,results={}):
+    def score(self, results=None):
+        if results is None:
+            results = {}
         """Calculate the scores for each chunk, returning an array of non-zero scores (potential break points)
         If the results parameter is given, then the return value is a summation
         """


### PR DESCRIPTION
## Summary

- Fixes two self-assignment no-ops in the `PARUSERSYNC` merge branch that should be copying fields from `acc[bi]` into `acc[i]` (bug 18)
- Fixes a mutable default argument `{}` in `score()` that causes scores to accumulate across calls (bug 19)

Both are in `python/lib/ptxprint/usfmerge.py`.

---

## Bug 18 — Self-assignment no-ops in PARUSERSYNC merge

### What is broken

```python
self.acc[i].verse = self.acc[i].verse   # no-op
self.acc[i].pnum  = self.acc[i].pnum    # no-op
```

Both lines assign a field to itself. The surrounding context (the `PARUSERSYNC` branch) is copying the first element of `acc[bi]` into `acc[i]` and marking `acc[bi]` for deletion — a pattern where `acc[i]` should inherit `bi`'s position data. The analogous code elsewhere in the function (lines 571–572) correctly reads from `self.acc[bi]`.

### Why it matters

The intended copy/merge operation silently does nothing. After the merge, `acc[i]` retains its own stale verse and pnum values instead of inheriting them from `acc[bi]`. This produces incorrect chunk positioning when `PARUSERSYNC` markers are present.

### How it was fixed

Changed both right-hand sides from `self.acc[i]` to `self.acc[bi]`, mirroring the correct pattern used earlier in the same function.

---

## Bug 19 — Mutable default argument `{}` in `score()`

### What is broken

```python
def score(self, results={}):
```

The `{}` default is created **once** at class-definition time and shared across every call that omits the `results` argument. Scores written into `results` on one call persist into the next call, so subsequent invocations see stale data from previous runs.

### Why it matters

This is the classic Python mutable-default-argument bug. Alignment scores accumulate across multiple `score()` calls instead of starting fresh each time, producing incorrect scores for any book processed after the first.

### How it was fixed

Changed the signature to `results=None` and added the standard guard at the top of the function body:

```python
def score(self, results=None):
    if results is None:
        results = {}
```

This creates a fresh dict on each call that doesn't supply one explicitly.

---

## Files changed

- `python/lib/ptxprint/usfmerge.py`

## Bug reports

`bugs/python/bug-18-self-assignment-noop/` and `bugs/python/bug-19-mutable-default-arg/` (local only, not committed)