### PR TITLE
fix: bare except on Windows DPI and WindowGeometry drops frame fields on restore

### DIFF
--- a/python/lib/ptxprint/gtkview.py
+++ b/python/lib/ptxprint/gtkview.py
@@ -678,7 +678,9 @@ class WindowGeometry:
             x=gi("x", -1), y=gi("y", -1), width=gi("width", 800), height=gi("height", 600),
             maximized=gb("maximized", False),
             monitor=gi("monitor", 0),
-            mon_x=gi("mon_x", 0), mon_y=gi("mon_y", 0), mon_w=gi("mon_w", 0), mon_h=gi("mon_h", 0)
+            mon_x=gi("mon_x", 0), mon_y=gi("mon_y", 0), mon_w=gi("mon_w", 0), mon_h=gi("mon_h", 0),
+            outer_w=gi("outer_w", 0), outer_h=gi("outer_h", 0),
+            dx=gi("dx", 0), dy=gi("dy", 0)
         )
 
     def toConfig(self, userconfig, name):
@@ -830,7 +832,7 @@ class GtkViewModel(ViewModel):
             # Set DPI awareness
             try:
                 windll.shcore.SetProcessDpiAwareness(2)  # DPI_AWARENESS_PER_MONITOR_AWARE
-            except:
+            except Exception:
                 windll.user32.SetProcessDPIAware()  # Fallback for older Windows versions
 
         if not self.args.quiet:


### PR DESCRIPTION
## Summary

- Replaces a bare `except:` with `except Exception:` in the Windows DPI awareness setup to avoid swallowing `KeyboardInterrupt` (bug 21)
- Fixes `WindowGeometry.fromConfig` not reading `outer_w`, `outer_h`, `dx`, `dy` fields, causing frame geometry to not be restored between sessions (bug 22)

Both are in `python/lib/ptxprint/gtkview.py`.

---

## Bug 21 — Bare `except:` on Windows DPI setup

### What is broken

```python
try:
    windll.shcore.SetProcessDpiAwareness(2)
except:
    windll.user32.SetProcessDPIAware()
```

The bare `except:` catches `BaseException` subclasses including `KeyboardInterrupt` and `SystemExit`. If the user presses Ctrl-C during application startup (while DPI configuration runs), the interrupt is silently swallowed and execution continues.

### Why it matters

Users who press Ctrl-C to abort a slow startup cannot do so reliably — the interrupt is consumed and ignored, leaving the application running.

### How it was fixed

Changed `except:` to `except Exception:`, which excludes `BaseException` subclasses like `KeyboardInterrupt` and `SystemExit`.

---

## Bug 22 — `WindowGeometry.fromConfig` drops frame fields on restore

### What is broken

`WindowGeometry` is a dataclass with fields including `outer_w`, `outer_h`, `dx`, and `dy` (the outer window frame dimensions and position offset). `toConfig` saves **all** fields via `asdict(self)`. However, `fromConfig` only reads back a subset:

```python
return cls(
    x=gi("x", -1), y=gi("y", -1), width=gi("width", 800), height=gi("height", 600),
    maximized=gb("maximized", False),
    monitor=gi("monitor", 0),
    mon_x=gi("mon_x", 0), mon_y=gi("mon_y", 0), mon_w=gi("mon_w", 0), mon_h=gi("mon_h", 0)
    # outer_w, outer_h, dx, dy missing ← always default to 0
)
```

`outer_w`, `outer_h`, `dx`, and `dy` are always initialised to `0` after a restart, even if they were saved by `toConfig` in a previous session.

### Why it matters

The window frame geometry is not fully restored between sessions. The window may appear slightly mis-positioned or sized differently from where the user left it, as the frame offset and size corrections are lost.

### How it was fixed

Added the four missing reads to `fromConfig`:

```python
outer_w=gi("outer_w", 0), outer_h=gi("outer_h", 0),
dx=gi("dx", 0), dy=gi("dy", 0)
```

These use the same key naming convention as `toConfig` (`{name}_{field}`) with `0` as the fallback, so existing configs without these fields continue to work.

---

## Files changed

- `python/lib/ptxprint/gtkview.py`

## Bug reports

`bugs/python/bug-21-bare-except-dpi/` and `bugs/python/bug-22-windowgeometry-missing-fields/` (local only, not committed)