### PR TITLE
fix: \getcalleres typo — alphabetic auto-callers always produce wrong symbol

### DIFF
--- a/src/ptx-callers.tex
+++ b/src/ptx-callers.tex
@@ -75,7 +75,7 @@
       \loop\ifnum\c@llernum>\AutoCallerNumChars
         \advance\c@llernum by -\AutoCallerNumChars \repeat
       \advance\c@llernum by -1 \advance\c@llernum by \AutoCallerStartChar
-      \edef\getcalleres{\char\c@llernum}% generate an alphabetic auto-caller
+      \edef\getcallerres{\char\c@llernum}% generate an alphabetic auto-caller
     \else
       \edef\getcallerres{\number\c@llernum}% generate a numeric caller
     \fi


### PR DESCRIPTION
## Summary

- Fixes a one-character typo `\getcalleres` → `\getcallerres` in the alphabetic auto-caller branch of `ptx-callers.tex`, which caused every alphabetic note caller to silently produce the wrong or empty symbol

---

## TeX Bug 01 — `\getcalleres` typo

### What is broken

The alphabetic branch of `\getcaller` stores its result in `\getcalleres` (missing the second `r`):

```tex
\edef\getcalleres{\char\c@llernum}%   ← typo: missing 'r'
```

But all callers — including `\gen@utonum` — read from `\getcallerres` (correct spelling):

```tex
\x@\getcaller\x@{\n@mber}{#1}\edef\them@rk{\getcallerres}
```

The numeric branch on the next line uses the correct name `\getcallerres`. The result is that whenever the default alphabetic caller sequence is active, `\getcallerres` is never written by this branch — it retains whatever stale or empty value it had from a previous call (or its initial `\def\getcallerres{}`), and the caller character rendered on every note is wrong or blank.

### Why it matters

Alphabetic auto-callers are the **default** mode for footnote callers in PTXprint. This means every document using the default footnote caller configuration silently renders incorrect caller symbols. The defect is invisible unless the user explicitly checks the caller characters in the output.

### How it was fixed

Changed `\getcalleres` to `\getcallerres` on the affected line. Confirmed no other occurrences of the misspelling exist in the file.

---

## Files changed

- `src/ptx-callers.tex`

## Bug report

`bugs/tex/bug-01-getcalleres-typo/` (local only, not committed)