### PR TITLE
fix: \set@utonum second \edef overwrites diglot-adjusted result

### DIFF
--- a/src/ptx-callers.tex
+++ b/src/ptx-callers.tex
@@ -162,7 +162,6 @@
     \fi
   \fi\fi\fi}
 \def\set@utonum#1{\set@notesavetype{#1}\edef\@utonum{autonum\@notesavetype}%
-    \edef\@utonum{autonum#1\c@rrdstat}%
 }
 
 %% override the autonumber macro from ptx-note-style.tex:


### PR DESCRIPTION
## Summary

- Fixes `\set@utonum` in `ptx-callers.tex` where a second `\edef\@utonum` immediately overwrites the result computed by `\set@notesavetype`, discarding diglot/parallel-note numbering logic

---

## TeX Bug 02 — `\set@utonum` overwrites its own result

### What is broken

```tex
\def\set@utonum#1{\set@notesavetype{#1}\edef\@utonum{autonum\@notesavetype}%
    \edef\@utonum{autonum#1\c@rrdstat}%   ← overwrites the line above
}
```

`\set@notesavetype{#1}` computes `\@notesavetype` — adjusting it for the diglot/parallel-note case when `\ParallelNoteNumbering` is in effect (e.g. prepending `\c@rrdstat` to the style name in a specific order). The first `\edef\@utonum` correctly uses this adjusted value. The second `\edef\@utonum` then immediately overwrites it with a direct concatenation `autonum#1\c@rrdstat`, bypassing the adjustment logic entirely. The first line is dead code.

The two forms are subtly different: `\set@notesavetype` sets `\@notesavetype` to `\c@rrdstat#1` (stat *then* arg) when in parallel-notes diglot mode, whereas the second line produces `#1\c@rrdstat` (arg *then* stat). Only the first form is correct.

### Why it matters

In diglot documents using `\ParallelNoteNumbering`, note counters use `\@utonum` to look up the running count. Because `\@utonum` is set to the wrong key, the parallel-note counter lookup finds the wrong (or absent) counter, producing incorrect note numbering in parallel-notes diglot mode.

### How it was fixed

Removed the second `\edef\@utonum` line, preserving the first (correct) one that uses the value computed by `\set@notesavetype`.

---

## Files changed

- `src/ptx-callers.tex`

## Bug report

`bugs/tex/bug-02-set-utonum-overwrites/` (local only, not committed)