### PR TITLE
fix: \nonstopmode in \d@shadow never reset — silences all TeX errors

### DIFF
--- a/src/ptx-char-style.tex
+++ b/src/ptx-char-style.tex
@@ -477,14 +477,16 @@
   \x@\shdwmul#2 \E
   \edef\@@outlinw{\strip@pt{\dimexpr #4\FontSizeUnit \relax}}%
   \edef\@@outcol{#5}\edef\@@shadcol{#3}\edef\@@fgcol{#6}% 
+  \edef\sv@interactionmode{\the\interactionmode}%
   \nonstopmode
   \tracingassigns=1
   \everypar={}\everyhbox={}\setbox#1=\vbox{\hfuzz=\maxdimen \hsize=1em \hyphenpenalty=10000 \leftskip=0pt \rightskip=0pt \unhbox#1 \endgraf
   \@do@shadow}%
-  \ifdim \wd#1=0pt \else %\showbox#1 
+  \ifdim \wd#1=0pt \else %\showbox#1
     \setbox#1\hbox{\@@do@shadow{#1}}%
     \unhbox#1\fi
   \tracingassigns=0
+  \interactionmode=\sv@interactionmode
   }%
   %\showbox\ulb@x
   \setbox#1\box\ulb@x


### PR DESCRIPTION
## Summary

- Fixes `\nonstopmode` being called inside `\d@shadow` (`ptx-char-style.tex`) without ever being reset, causing TeX to run in nonstop mode for the entire remainder of the job after any shadow or outline character style is first used

---

## TeX Bug 03 — `\nonstopmode` never reset

### What is broken

Inside `\d@shadow`, `\nonstopmode` is called to suppress a `\tracingassigns` warning flood that would otherwise interrupt typesetting:

```tex
\nonstopmode
\tracingassigns=1
...
\tracingassigns=0
```

`\nonstopmode` is a **global** TeX primitive — it changes the interaction mode for the entire engine, not just the current group. It is never matched by a corresponding `\errorstopmode` or `\scrollmode` call to restore the previous mode.

### Why it matters

After the first use of any shadow or outline character style in a document, TeX enters nonstop mode permanently for the rest of that run. All subsequent TeX errors — missing fonts, bad macros, overfull boxes flagged as errors, undefined control sequences — scroll past silently without pausing. Legitimate errors that the user should see and fix become invisible. This makes debugging such documents significantly harder and can allow serious typesetting errors to go unnoticed.

### How it was fixed

Save and restore the interaction mode around the `\nonstopmode` call using TeX's `\interactionmode` internal register:

```tex
\edef\sv@interactionmode{\the\interactionmode}%
\nonstopmode
\tracingassigns=1
...
\tracingassigns=0
\interactionmode=\sv@interactionmode
```

The saved/restored value is local to the outer group in `\d@shadow`, ensuring that after the shadow processing completes, the engine returns to exactly the interaction mode it had before.

---

## Files changed

- `src/ptx-char-style.tex`

## Bug report

`bugs/tex/bug-03-nonstopmode-not-reset/` (local only, not committed)