### PR TITLE
fix: duplicate \gdef\startch@rstyle@extend in ptx-char-style.tex

### DIFF
--- a/src/ptx-char-style.tex
+++ b/src/ptx-char-style.tex
@@ -211,7 +211,6 @@
 {
  \catcode`\^=12 
  \gdef\startch@rstyle@extend^#1 {\edef\ch@rfontextend{\p@rcent#1xx\E}\startch@rstyle}%
- \gdef\startch@rstyle@extend^#1 {\edef\ch@rfontextend{\p@rcent#1xx\E}\startch@rstyle}%
 }
 %-cchar_docharstyle
 


### PR DESCRIPTION
## Summary

- Removes a duplicate identical `\gdef\startch@rstyle@extend` definition in `ptx-char-style.tex`

---

## TeX Bug 04 — Duplicate `\gdef\startch@rstyle@extend`

### What is broken

Inside the `\lowercase{...}` block that sets up character-style extension syntax, the same macro is defined twice in sequence with identical bodies:

```tex
{
 \catcode`\^=12
 \gdef\startch@rstyle@extend^#1 {...}%
 \gdef\startch@rstyle@extend^#1 {...}%   ← identical duplicate
}
```

The second `\gdef` silently overwrites the first with the same definition.

### Why it matters

There is no runtime impact since the two definitions are identical. However, the duplicate is almost certainly a copy-paste oversight and constitutes dead code. If the two definitions ever diverged (e.g. during a future edit where only one is updated), it would create a subtle bug where one definition silently shadows the other.

### How it was fixed

Removed the second (duplicate) `\gdef\startch@rstyle@extend` line.

---

## Files changed

- `src/ptx-char-style.tex`

## Bug report

`bugs/tex/bug-04-duplicate-gdef/` (local only, not committed)