### PR TITLE
fix: \LeftMarksfalse calls wrong macro and \useRigth* typos in ptx-diglot.tex

### DIFF
--- a/src/ptx-diglot.tex
+++ b/src/ptx-diglot.tex
@@ -78,8 +78,8 @@
 \def\n@xtfirstRmark{} %First Rmark in the n@xt chunk
 \def\n@xtbotLmark{} %First Lmark in the n@xt chunk
 \def\n@xtbotRmark{} %First Rmark in the n@xt chunk
-\def\LeftMarkstrue{\useLeftMarkstrue\useRigthMarksfalse}
-\def\LeftMarksfalse{\useLeftMarkstrue\useRigthMarkstrue}
+\def\LeftMarkstrue{\useLeftMarkstrue\useRightMarksfalse}
+\def\LeftMarksfalse{\useLeftMarksfalse\useRightMarkstrue}
 \def\m@xBelowBaseline{0pt}%
 \def\@fnLht{0pt}
 \def\@fnRht{0pt}


### PR DESCRIPTION
## Summary

- Fixes `\LeftMarksfalse` calling `\useLeftMarkstrue` (same as `\LeftMarkstrue`) instead of `\useLeftMarksfalse`
- Fixes `\useRigthMarksfalse` / `\useRigthMarkstrue` typos (missing `h`) that call undefined macros

Both defects are on adjacent lines in `ptx-diglot.tex`.

---

## TeX Bug 05 — `\LeftMarksfalse` calls wrong macro; `\useRigth*` typos

### What is broken

```tex
\def\LeftMarkstrue {\useLeftMarkstrue \useRigthMarksfalse}
\def\LeftMarksfalse{\useLeftMarkstrue \useRigthMarkstrue}
                    ^^^^^^^^^^^^^^^ same as above — should be \useLeftMarksfalse
```

**Problem 1 — inverted logic:** `\LeftMarksfalse` calls `\useLeftMarkstrue` — exactly the same call as `\LeftMarkstrue`. Both macros are therefore identical; enabling and disabling left marks have no difference in effect.

**Problem 2 — undefined macros:** Both lines call `\useRigthMarksfalse` and `\useRigthMarkstrue` (missing `h` in `Right`). The conditional `\newif\ifuseRightMarks` creates `\useRightMarksfalse` and `\useRightMarkstrue` (with `h`). The misspelled `\useRigth*` macros are undefined.

### Why it matters

In diglot mode, header/footer mark selection (whether to use marks from the left or right column) is completely broken:

- `\LeftMarksfalse` acts identically to `\LeftMarkstrue`, so there is no way to actually disable left marks.
- Both calls to `\useRigth*` invoke undefined control sequences. Depending on the TeX error mode this either silently does nothing or raises an error, meaning the `ifuseRightMarks` conditional is never correctly set.

The result is that diglot running header/footer content from the right column is never correctly enabled or disabled, producing wrong headers/footers in diglot documents.

### How it was fixed

Corrected both lines to:

```tex
\def\LeftMarkstrue {\useLeftMarkstrue \useRightMarksfalse}
\def\LeftMarksfalse{\useLeftMarksfalse\useRightMarkstrue}
```

Confirmed no other occurrences of `\useRigth` (the misspelling) remain in the file.

---

## Files changed

- `src/ptx-diglot.tex`

## Bug report

`bugs/tex/bug-05-leftmarks-logic-typo/` (local only, not committed)