### PR TITLE
fix: \f@rstnotefalse set before \iff@rstnote check — first-note spacing never applied in sep mode

### DIFF
--- a/src/ptx-output.tex
+++ b/src/ptx-output.tex
@@ -768,7 +768,6 @@
   \TRACE{class \cl@sss}%
   \x@\let\x@\th@cl@ss\csname note-\cl@sss\endcsname
   \ifvoid\th@cl@ss\trace{f}{Notes[#1] empty}\else
-    \global\f@rstnotefalse
     \global\advance\availht by -\ht\th@cl@ss
     \global\advance\availht by -\dp\th@cl@ss
     \iff@rstnote\advance\availht by -\AboveNoteSpace


### PR DESCRIPTION
## Summary

- Fixes `\reduceavailht@sep` in `ptx-output.tex` where `\global\f@rstnotefalse` is called unconditionally *before* the `\iff@rstnote` test, making the first-note spacing branch permanently unreachable

---

## TeX Bug 06 — `\f@rstnotefalse` set before `\iff@rstnote` check

### What is broken

```tex
\def\reduceavailht@sep#1{%
  ...
  \ifvoid\th@cl@ss\trace{f}{Notes[#1] empty}\else
    \global\f@rstnotefalse          ← clears the flag HERE (unconditionally)
    \global\advance\availht by -\ht\th@cl@ss
    \global\advance\availht by -\dp\th@cl@ss
    \iff@rstnote                    ← flag is already false; this can NEVER be true
      \advance\availht by -\AboveNoteSpace
      \global\advance\availht by -\BelowFootNoteSpace
      ...
      \global\f@rstnotefalse        ← already false; this is a no-op
    \else
      \global\advance\availht by -\InterNoteSpace
    \fi
  \fi}
```

`\f@rstnotefalse` is called globally *before* the `\iff@rstnote` conditional. Once the flag is cleared, the check `\iff@rstnote` can never be true. The entire first-note-spacing block (lines 774–778) is dead code.

Compare `\reduceavailht@para`, which correctly checks `\iff@rstnote` *before* clearing it.

### Why it matters

`\AboveNoteSpace` and `\BelowFootNoteSpace` are never subtracted from the available page height for the first note in separate-note mode. This miscalculates available height, causing TeX to overestimate how much space is left on the page. The result is overfull pages or incorrect page breaks when separate-style footnotes are used — a layout defect that is easy to miss because it is most visible with dense footnote content.

### How it was fixed

Removed the premature `\global\f@rstnotefalse` call from before the `\iff@rstnote` block. The existing `\global\f@rstnotefalse` inside the `\iff@rstnote` branch (line 778) already clears the flag at the correct time, so no additional change is needed. This mirrors the structure of `\reduceavailht@para`.

---

## Files changed

- `src/ptx-output.tex`

## Bug report

`bugs/tex/bug-06-firstnote-false-before-check/` (local only, not committed)