### PR TITLE
fix: \if\tmp\relax should be \ifx\tmp\empty in figure scale parsing

### DIFF
--- a/src/ptx-figure.tex
+++ b/src/ptx-figure.tex
@@ -212,7 +212,7 @@
   \trace{g}{p@rsesize #1*#2*#3}%
   \global\def\size@ption{#1}%
   \edef\tmp{#2}%
-  \if\tmp\relax\relax\else\def\sizem@ltiple{#2}\trace{g}{Setting scale to #2}\fi% empty if not provided
+  \ifx\tmp\empty\else\def\sizem@ltiple{#2}\trace{g}{Setting scale to #2}\fi% empty if not provided
 }
 %-cfig_parsesize
 


### PR DESCRIPTION
## Summary

- Fixes a wrong conditional primitive in `\p@rsesize` (`ptx-figure.tex`) where `\if\tmp\relax\relax` (character-code comparison) should be `\ifx\tmp\empty` (macro-equality test)

---

## TeX Bug 07 — `\if\tmp\relax` should be `\ifx\tmp\empty`

### What is broken

```tex
\def\p@rsesize#1*#2*#3\end{%
  \global\def\size@ption{#1}%
  \edef\tmp{#2}%
  \if\tmp\relax\relax\else\def\sizem@ltiple{#2}...\fi
}
```

`\if` is TeX's **character-code comparison** primitive. `\if\tmp\relax\relax` does not test whether `\tmp` is undefined or empty — it expands `\tmp` and `\relax` to single tokens and compares their character codes. When `#2` (the scale parameter) is absent (empty string), `\edef\tmp{}` makes `\tmp` an empty macro. `\if` then sees no token from `\tmp` and advances to compare `\relax` with `\relax`, which happens to be true by accident.

While this works in the common empty case, it is semantically wrong. If `\tmp` ever expands to a single token whose character code coincidentally matches `\relax`'s internal character code (0), the condition will incorrectly evaluate as true and the scale will not be set even though a value was provided.

### Why it matters

Scale parameter detection for figure sizing is fragile and dependent on accidental character-code coincidence rather than the correct empty-macro test. Edge-case scale values could cause the scale multiplier `\sizem@ltiple` to be incorrectly skipped, resulting in figures rendered at the wrong size with no diagnostic.

### How it was fixed

Changed `\if\tmp\relax\relax` to `\ifx\tmp\empty`. `\ifx` performs a **token-list equality** test — it correctly tests whether `\tmp` is identical to the primitive `\empty` (the empty macro), which is exactly what `\edef\tmp{}` produces when `#2` is absent.

---

## Files changed

- `src/ptx-figure.tex`

## Bug report

`bugs/tex/bug-07-wrong-if-conditional/` (local only, not committed)