### PR TITLE
fix: \penalty0 allows page break before first note body — replace with \nobreak

### DIFF
--- a/src/ptx-note-style.tex
+++ b/src/ptx-note-style.tex
@@ -537,7 +537,7 @@
   \par
   \ifp@ranotes\@ch@ckadjustments
   \else\getp@ram{spaceafter}{\n@tetype}{\n@tetype}\trace{n}{note(\n@tetype) spaceafter: \p@ram}%
-    \ifx\p@ram\relax\penalty0 \else\vskip\p@ram\verticalsp@ceunit\fi %FIXME Penalty0??? 
+    \ifx\p@ram\relax\nobreak \else\vskip\p@ram\verticalsp@ceunit\fi % prevent page break before first note body
     \setbox0=\hbox to 0pt{\XeTeXuseglyphmetrics=0 \char32 \hss}%
     % surely we don't want a strut above and below?
     %\dimen0=\baselineskip \advance\dimen0 by -\ht0 \advance\dimen0 by -\prevdepth


### PR DESCRIPTION
## Summary

- Fixes a `\penalty0` (which *permits* a page break) used between the footnote rule and the first note body in `ptx-note-style.tex`, replacing it with `\nobreak` to prevent an orphaned rule at the bottom of a page

---

## TeX Bug 08 — `\penalty0` (FIXME) allows page break between notes

### What is broken

```tex
\ifx\p@ram\relax\penalty0 \else\vskip\p@ram\verticalsp@ceunit\fi %FIXME Penalty0???
```

When no `spaceafter` parameter is defined for a note type, `\p@ram` is `\relax` and the code inserts `\penalty0`. A penalty of 0 is a **zero penalty** — it explicitly *allows* a page break at that point. The `FIXME` comment in the source already flags this as suspicious.

This point in the code sits between the footnote rule and the body of the first footnote. A page break here would place the footnote rule at the bottom of one page with the footnote content starting on the next page — producing an orphaned rule with no visible notes below it.

### Why it matters

In rare but real layout conditions — particularly when the last line before the footnote area is tight — TeX may choose to break the page at this zero-penalty point. The result is a page that ends with just the footnote separator rule and no footnote text, which is a clear typesetting defect. Because the break is layout-dependent it is easy to miss in short test documents and only surfaces in production.

### How it was fixed

Changed `\penalty0` to `\nobreak`. `\nobreak` inserts an infinite penalty (`\penalty10000`) that explicitly *prevents* a page break at this point, ensuring the footnote rule and first note body always appear on the same page. The FIXME comment has been replaced with a clarifying comment.

---

## Files changed

- `src/ptx-note-style.tex`

## Bug report

`bugs/tex/bug-08-penalty0-fixme/` (local only, not committed)