### PR TITLE
Fix for reverting to monoglot dialog

### DIFF
--- a/python/lib/ptxprint/gtkview.py
+++ b/python/lib/ptxprint/gtkview.py
@@ -5524,6 +5524,7 @@ class GtkViewModel(ViewModel):
             self._monoglotDlgSigConnected = True
 
         dialog   = self.builder.get_object("dlg_saveAsMonoglot")
+        dialog.show_all()
         response = dialog.run()
         dialog.hide()
 


### PR DESCRIPTION
Most of the dialog contents were not rendering.