### PR TITLE
Fix crash reading font collections with no US English family name (macOS Arial, Courier)

### DIFF
--- a/python/lib/ptxprint/font.py
+++ b/python/lib/ptxprint/font.py
@@ -679,17 +679,26 @@ class TTFont:
                 numc = struct.unpack(">L", dat[8:])[0]
                 ttcdat = inf.read(numc * 4)
                 if ttcindex is None:
+                    firstdir = None
                     for i in range(numc):
                         offset = struct.unpack(">L", ttcdat[4*i:4*(i+1)])[0]
                         inf.seek(offset)
                         dat = inf.read(12)
                         numtables = struct.unpack(">H", dat[4:6])[0]
                         thisdir = self._read_dir(inf, numtables)
-                        thisnames = self.readNames(inf, dirdic=thisdir)
+                        thisnames = self.readNames(inf, dirdic=thisdir) or {}
+                        if firstdir is None:
+                            firstdir = thisdir
                         if thisnames.get(1, "") == self.family:     # Mac fonts don't obey standards?
                             self.dict = thisdir
                             ttcindex = i
                             break
+                    else:
+                        # Collections such as macOS Arial or Courier have no US English
+                        # family name to match against, so fall back to the first font
+                        if firstdir is not None:
+                            self.dict = firstdir
+                            ttcindex = 0
                 else:
                     offset = struct.unpack(">L", ttcdat[4*ttcindex:4*(ttcindex+1)])[0]
                     inf.seek(offset)
@@ -698,7 +707,9 @@ class TTFont:
                     self.dict = self.read_dir(inf, numtables)
             else:
                 self.dict = self._read_dir(inf, numtables)
-            self.names = self.readNames(inf)
+            if not len(self.dict):
+                return False
+            self.names = self.readNames(inf) or {}
             self.readFeat(inf)
             self.readSill(inf)
             self.readOTFeats(inf)

--- a/test/test_font.py
+++ b/test/test_font.py
@@ -1,0 +1,111 @@
+#!/usr/bin/python3
+
+import unittest, os, struct, tempfile
+from ptxprint.font import TTFont, initFontCache
+
+fontsdir = os.path.join(os.path.dirname(__file__), "fonts")
+
+def mkhead(upem):
+    return struct.pack(">18s H 34s", b"\0" * 18, upem, b"\0" * 34)
+
+def mkname(names):
+    ''' Build a name table holding Windows US English records for names: {nameID: string} '''
+    recs = b""
+    strings = b""
+    for nid, val in sorted(names.items()):
+        dat = val.encode("utf_16_be")
+        recs += struct.pack(">HHHHHH", 3, 1, 1033, nid, len(dat), len(strings))
+        strings += dat
+    return struct.pack(">HHH", 0, len(names), 6 + len(recs)) + recs + strings
+
+def mkttc(faces):
+    ''' Build a font collection where each face is a {tag: data} mapping of tables '''
+    hdr = struct.pack(">4sLL", b"ttcf", 0x00010000, len(faces))
+    diroff = len(hdr) + 4 * len(faces)
+    diroffs = []
+    for f in faces:
+        diroffs.append(diroff)
+        diroff += 12 + 16 * len(f)
+    dat = b""
+    dirs = b""
+    for f in faces:
+        dirs += struct.pack(">LHHHH", 0x00010000, len(f), 0, 0, 0)
+        for tag, tdat in sorted(f.items()):
+            dirs += struct.pack(">4sLLL", tag, 0, diroff + len(dat), len(tdat))
+            dat += tdat
+    return hdr + b"".join(struct.pack(">L", o) for o in diroffs) + dirs + dat
+
+def writettc(faces):
+    f = tempfile.NamedTemporaryFile(suffix=".ttc", delete=False)
+    f.write(mkttc(faces))
+    f.close()
+    return f.name
+
+
+class TestTTCollection(unittest.TestCase):
+    ''' macOS ships families like Arial and Courier as collections whose faces carry
+        no US English family name, so the family search can never match (#1093). '''
+
+    @classmethod
+    def setUpClass(cls):
+        initFontCache(nofclist=True)    # these fonts are read by name, not looked up
+
+    def setUp(self):
+        self.tmps = []
+
+    def tearDown(self):
+        TTFont.cache.clear()
+        for f in self.tmps:
+            os.unlink(f)
+
+    def mkfont(self, faces, family, style=""):
+        fname = writettc(faces)
+        self.tmps.append(fname)
+        TTFont.cache.clear()
+        return TTFont(family, style, filename=fname)
+
+    def test_no_family_names(self):
+        faces = [{b"head": mkhead(1000), b"name": mkname({2: "Regular"})},
+                 {b"head": mkhead(2048), b"name": mkname({2: "Bold"})}]
+        f = self.mkfont(faces, "Courier", "Bold")
+        self.assertEqual(f.upem, 1000)
+        self.assertEqual(f.family, "Courier")
+
+    def test_family_not_in_collection(self):
+        faces = [{b"head": mkhead(1000), b"name": mkname({1: "Avenir", 2: "Regular"})},
+                 {b"head": mkhead(2048), b"name": mkname({1: "Avenir", 2: "Bold"})}]
+        f = self.mkfont(faces, "Not A Font Family")
+        self.assertEqual(f.upem, 1000)
+
+    def test_unknown_family(self):
+        ''' TTFontCache.addFontDir reads a file before it knows the family '''
+        faces = [{b"head": mkhead(1000), b"name": mkname({1: "Avenir", 2: "Regular"})}]
+        f = self.mkfont(faces, None)
+        self.assertEqual(f.upem, 1000)
+        self.assertEqual(f.family, "Avenir")
+
+    def test_face_without_name_table(self):
+        faces = [{b"head": mkhead(1000)},
+                 {b"head": mkhead(2048), b"name": mkname({1: "Avenir", 2: "Bold"})}]
+        f = self.mkfont(faces, "Avenir", "Bold")
+        self.assertEqual(f.upem, 2048)
+
+    def test_matching_family_wins(self):
+        faces = [{b"head": mkhead(1000), b"name": mkname({1: "Avenir", 2: "Regular"})},
+                 {b"head": mkhead(2048), b"name": mkname({1: "Charis", 2: "Regular"})}]
+        f = self.mkfont(faces, "Charis")
+        self.assertEqual(f.upem, 2048)
+
+    def test_empty_collection(self):
+        f = self.mkfont([], "Avenir")
+        self.assertIsNone(f.filename)
+
+    def test_plain_font_unaffected(self):
+        TTFont.cache.clear()
+        f = TTFont("Charis SIL", "", filename=os.path.join(fontsdir, "CharisSIL-Regular.ttf"))
+        self.assertEqual(f.family, "Charis SIL")
+        self.assertEqual(f.upem, 2048)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR proposes a fix for the crash PTXprint hits when it reads a font collection whose faces carry no US English family name, which is what makes selecting Arial or Courier fail on macOS (fixes #1093). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/505. You can sign in with your GitHub ID to claim ownership of the project.

## What goes wrong

`TTFont.readfont` walks a `.ttc` collection looking for a face whose name ID 1 equals `self.family`, and stops there. When no face matches, `self.dict` keeps the empty `{}` it was initialised to and execution falls straight through to `readhead`, which is the one table reader with no `if 'head' not in self.dict` guard. Commit 621ef00f4 replaced `thisnames[1]` with `thisnames.get(1, "")`, which removed the `KeyError: 1` at the top of the traceback in #1093 — but the crash moved rather than disappeared, because a face with no name ID 1 still cannot match, and a collection with no matching face still leaves an empty table directory behind. The report now surfaces as `KeyError: 'head'` five frames lower.

macOS is where this bites. Several system families ship as collections whose faces expose only name ID 2 (the subfamily) in the Windows/US-English records that `readNames` accepts, so every face scores `""` against the requested family and the search can never succeed. On this machine that is true of `ArialHB.ttc`, `Courier.ttc`, `Apple Color Emoji.ttc` and `AppleSDGothicNeo.ttc`, among others. Linux and Windows ship the same faces as individual `.ttf` files, which take the non-collection branch — which is why the reporter saw it only on macOS.

`TTFontCache.addFontDir` falls into the same hole from the other direction: it calls `TTFont(None, filename=fpath)` precisely because it does not yet know the family, so `thisnames.get(1, "") == None` is false for every face of every collection, and adding a font folder containing any `.ttc` throws.

### Reproduced on current master (b1588d8a3)

```
$ python -c "from ptxprint.font import TTFont; TTFont('Courier', 'Bold', filename='/System/Library/Fonts/Courier.ttc')"
Traceback (most recent call last):
  ...
  File "python/lib/ptxprint/font.py", line 644, in __init__
    if self.readfont():
  File "python/lib/ptxprint/font.py", line 707, in readfont
    self.readhead(inf)
  File "python/lib/ptxprint/font.py", line 880, in readhead
    inf.seek(self.dict['head'][0])
KeyError: 'head'
```

Sweeping every font file under `/System/Library/Fonts` (including `Supplemental`) through `TTFont(...)` on master raises for 204 of the 298 (family, file) combinations tried.

## The change

`python/lib/ptxprint/font.py`, all inside `readfont`:

* the collection walk now remembers the first face it read, and uses it when no face matched the requested family — a collection always contains real fonts, so reading one of them beats reading none, and it makes `addFontDir`'s deliberate `family=None` call work as intended;
* `readNames` returns `None` for a face with no `name` table, so its result is coalesced to `{}` before `.get` is called on it;
* if a table directory could not be read at all (a truncated or empty collection), `readfont` returns `False`, which is the existing "corrupted font so dump it" contract that `__init__` already handles — so `readhead` can no longer be reached with an empty `self.dict`.

An exact-family match still wins whenever one exists, so nothing changes for a collection that does name its faces conventionally.

## Verification

`test/test_font.py` is new and builds its collections byte by byte in a temp file, so it needs no system fonts and runs the same on every platform. Five of its seven cases fail on master and pass with the change:

```
$ git checkout upstream/master -- python/lib/ptxprint/font.py && pytest -q test/test_font.py
FAILED test/test_font.py::TestTTCollection::test_empty_collection - KeyError: 'head'
FAILED test/test_font.py::TestTTCollection::test_face_without_name_table - AttributeError: 'NoneType' object has no attribute 'get'
FAILED test/test_font.py::TestTTCollection::test_family_not_in_collection - KeyError: 'head'
FAILED test/test_font.py::TestTTCollection::test_no_family_names - KeyError: 'head'
FAILED test/test_font.py::TestTTCollection::test_unknown_family - KeyError: 'head'
5 failed, 2 passed in 0.45s

$ git checkout HEAD -- python/lib/ptxprint/font.py && pytest -q test/test_font.py
7 passed in 0.09s
```

The two that pass either way are deliberate controls: `test_matching_family_wins` checks that a named face is still preferred over the new fallback, and `test_plain_font_unaffected` checks that a single-face `.ttf` (`test/fonts/CharisSIL-Regular.ttf`) still reports the same family and upem.

Because a green suite only proves what it executes, the real reader was exercised on real data too. All 149 font files under `/System/Library/Fonts` and its `Supplemental` folder were loaded through `TTFont(...)` twice each, once with the file's own face-0 family and once with a family that is absent: 204 raises on master, 0 after the change. All 30 `.ttf` fixtures in `test/fonts` and `fonts` were re-read and report identical family, style, upem and Graphite flags before and after.

Suite state is otherwise unchanged: `pytest -q test/test_usfmx.py` is 9 passed before and after, and `pytest -q test/` stops at the same pre-existing collection error in `test_projects.py` on both trees (`test/projects/aArpBT` has no matching `test/standards/aArpBT`), which is untouched by this change.

## How this was managed

We imported this repository's issues and pull requests into a Tracker project and worked the fix from there. This PR maps to [Issue when enumerating font weights on macOS](https://eastagiletracker.com/projects/505/stories/443661), the story imported from #1093, on the board at https://eastagiletracker.com/projects/505 — 1248 stories and 23 labels, one story per issue and pull request, milestones as epics.

![board](https://raw.githubusercontent.com/eastagiletracker/ptx2pdf/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
